### PR TITLE
Put template in its own function

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "deploy": "npm run lint && npm run test",
     "lint": "jshint src/",
     "test": "mocha --timeout 5000 --recursive test/",
-    "build": "browserify src/embed.js -d -s ck.datasets > dist/ckan-embed.js",
+    "build": "browserify src/embed.js -d -s ck > dist/ckan-embed.js",
     "postbuild": "uglifyjs dist/ckan-embed.js -cm > dist/ckan-embed.min.js",
-    "watch": "watchify src/embed.js -v -d -s ck.datasets -o dist/ckan-embed.js"
+    "watch": "watchify src/embed.js -v -d -s ck -o dist/ckan-embed.js"
   },
   "main": "src/embed.js",
   "browserify-shim": {

--- a/src/embed.js
+++ b/src/embed.js
@@ -142,4 +142,6 @@ function datasets(el, url, options, callback) {
   } catch (err) { cb(err); }
 }
 
-module.exports = datasets;
+exports.datasets = datasets;
+exports.template = template;
+exports.generateView = generateView;

--- a/src/embed.js
+++ b/src/embed.js
@@ -8,17 +8,7 @@ var config = {};
 function generateView(div, url, packages, lang) {
 
   // Generate HTML of the widget
-  var template_widget = _.template(
-    '<div class="ckan-dataset">' +
-    '<a href="<%= ds.url %>">' +
-    '<h5><%= ds.title %></h5>' +
-    '</a>' +
-    '<p><%= ds.description %></p>' +
-    '<b><%= ds.groupname %></b><br>' +
-    '<small><%= ds.formats %></small>' +
-    //'<small><%= ds.modified %></small>' +
-    '</div>'
-  );
+  var template_widget = template();
 
   // Helper functions to massage the results
   var fragments = [];
@@ -48,7 +38,7 @@ function generateView(div, url, packages, lang) {
       formats:       getDatasetFormats(dso.resources),
       modified:      dso.metadata_modified
     };
-    fragments.push(template_widget({ ds: ds }));
+    fragments.push(template_widget({ ds: ds, dso: dso }));
   }
 
   if (fragments.length === 0) {
@@ -58,6 +48,22 @@ function generateView(div, url, packages, lang) {
   // Insert into the container on the page
   div.html(fragments.join(''));
 
+}
+
+function template() {
+  // Generate HTML of the widget
+  var template_widget = _.template(
+    '<div class="ckan-dataset">' +
+    '<a href="<%= ds.url %>">' +
+    '<h5><%= ds.title %></h5>' +
+    '</a>' +
+    '<p><%= ds.description %></p>' +
+    '<b><%= ds.groupname %></b><br>' +
+    '<small><%= ds.formats %></small>' +
+    //'<small><%= ds.modified %></small>' +
+    '</div>'
+  );
+  return template_widget;
 }
 
 // Embed a CKAN dataset result in a web page.


### PR DESCRIPTION
This allows developers to override this template method and define their
own template. If you want full control you could already override
generateView. And by exposing the original dataset object you give even
more freedom.